### PR TITLE
Fix typos

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,10 +2,10 @@
 
 * Many API changes.
 * Directory structure is changed (See README.md).
-* Some comannds are deprecated: `rebind`, `bind` and `open`.
-* Some comannds are removed: `commit`, `home`, `usage` and `clean`.
+* Some commands are deprecated: `rebind`, `bind` and `open`.
+* Some commands are removed: `commit`, `home`, `usage` and `clean`.
 * Many command options are removed.
-* New comands are added: `build`, `preview` and `publish`.
+* New commands are added: `build`, `preview` and `publish`.
 * Migration command `migrate` is added.
 
 # 0.2.3

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Please migrate via `retter migrate`.
 
 ## Contributing
 
-1. Fork it ( http://github.com/<my-github-username>/retter/fork )
+1. Fork it ( https://github.com/hibariya/retter/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
I fixed some typos.
- ChangeLog.md
  - 'comannds' / 'comands' should be 'commands'.
- README.md
  - Fix broken link.
